### PR TITLE
Replaced CC0 sentence to indicate instead that the upstream draft is CC0

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -2847,9 +2847,7 @@ and
 (<a href=//www.ibm.com/>IBM</a>,
 <a href=mailto:rubys@intertwingly.net>rubys@intertwingly.net</a>).
 
-<p>Per <a rel="license" href="//creativecommons.org/publicdomain/zero/1.0/">CC0</a>, to
-the extent possible under law, the editor has waived all copyright and related or
-neighboring rights to this work.
+<p>The upstream draft at <a href="https://url.spec.whatwg.org/">https://url.spec.whatwg.org/</a> is licensed under <a rel="license" href="//creativecommons.org/publicdomain/zero/1.0/">CC0</a>.
 
 <pre class="biblio"
 {


### PR DESCRIPTION
Makes it consistent with the license of the /TR snapshot
